### PR TITLE
fix: change start-str for fig description insertion

### DIFF
--- a/multimodal_rag/doc_intelligence.py
+++ b/multimodal_rag/doc_intelligence.py
@@ -160,7 +160,7 @@ def update_figure_description(md_content, img_description, idx):
     """
 
     # The substring you're looking for
-    start_substring = f"![](figures/{idx})"
+    start_substring = "<figure>"
     end_substring = "</figure>"
     new_string = f"<!-- FigureContent=\"{img_description}\" -->"
     


### PR DESCRIPTION
Hi, @monuminu! I'm a CSA at Microsoft Japan. Your sample code is useful, and customers using Azure are leveraging your sample code.
 

## Changes made: 
To insert figure captions every other day, the starting string used to find the insertion points in the Markdown was changed to `<figure>`.

## Issue: 
In the Markdown output from Document Intelligence, even though `<figure>` and `</figure>` were included, `![](figures/0)` was not. This meant that with the previous code, the caption was not inserted.

## Reference: 
Output format for Markdown in Document Intelligence - [Document Intelligence Markdown Output Format](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/prebuilt/layout?view=doc-intel-4.0.0&tabs=output&form=MG0AV3)"